### PR TITLE
Fixed Arbitrary instance for NestedBlock.

### DIFF
--- a/runtests.hs
+++ b/runtests.hs
@@ -69,7 +69,12 @@ newtype Blocks = Blocks { unBlocks :: [(Text, [(Text, Text)])] }
     deriving (Show, Eq)
 
 instance Arbitrary NestedBlock where
-    arbitrary = (LeafBlock . unBlock) `liftM` arbitrary
+    arbitrary = frequency
+      [ (80, (LeafBlock . unBlock) `liftM` arbitrary)
+      , (10, do mediatype <- elements ["print", "screen", "(min-width:768px)"]
+                contents <- arbitrary
+                return (NestedBlock mediatype contents))
+      ]
 
 instance Arbitrary Blocks where
     arbitrary = fmap (Blocks . map unBlock) arbitrary


### PR DESCRIPTION
Previously arbitrary would only generate a LeafBlock for NestedBlock.
Hence documents with NestedBlock were not really being tested at all!
With this change we can see the bug reported separately in #6.