### PR TITLE
Fix the build on GHC 8.4

### DIFF
--- a/Text/CSS/Render.hs
+++ b/Text/CSS/Render.hs
@@ -10,11 +10,9 @@ module Text.CSS.Render
 
 import Data.Text (Text)
 import Data.Text.Lazy.Builder (Builder, fromText, singleton)
-import Data.Monoid (mappend, mempty, mconcat)
+import Data.Monoid (mempty, mconcat)
+import Data.Semigroup ((<>))
 import Text.CSS.Parse
-
-(<>) :: Builder -> Builder -> Builder
-(<>) = mappend
 
 renderAttr :: (Text, Text) -> Builder
 renderAttr (k, v) = fromText k <> singleton ':' <> fromText v

--- a/css-text.cabal
+++ b/css-text.cabal
@@ -33,6 +33,9 @@ test-suite runtests
                    , hspec                     >= 1.3
                    , QuickCheck
 
+    if !impl(ghc >= 8.0)
+      build-depends: semigroups                >= 0.16.1
+
 source-repository head
   type:     git
   location: https://github.com/yesodweb/css-text.git

--- a/css-text.cabal
+++ b/css-text.cabal
@@ -18,7 +18,7 @@ library
                    , attoparsec                >= 0.10.2.0
 
     if !impl(ghc >= 8.0)
-    build-depends:   semigroups                >= 0.16.1
+      build-depends: semigroups                >= 0.16.1
 
     exposed-modules: Text.CSS.Parse
                      Text.CSS.Render

--- a/css-text.cabal
+++ b/css-text.cabal
@@ -16,6 +16,10 @@ library
     build-depends:   base                      >= 4        && < 5
                    , text                      >= 0.11
                    , attoparsec                >= 0.10.2.0
+
+    if !impl(ghc >= 8.0)
+    build-depends:   semigroups                >= 0.16.1
+
     exposed-modules: Text.CSS.Parse
                      Text.CSS.Render
     ghc-options:     -Wall


### PR DESCRIPTION
The `(<>)` function defined locally in `Text.CSS.Render` clashes with `(Data.Semigroup.<>)`, which is exported by the `Prelude` in `base-4.11` (GHC 8.4). A simple solution is to simply use `(Data.Semigroup.<>)` instead, since its use is entirely internal to this module.