### PR TITLE
Fix: parse blocks after nested blocks.

### DIFF
--- a/src/Text/CSS/Parse.hs
+++ b/src/Text/CSS/Parse.hs
@@ -75,12 +75,17 @@ attrsParser = (do
 blockParser :: Parser (Text, [(Text, Text)])
 blockParser = do
     skipWS
-    sel <- takeWhile (/= '{')
-    _ <- char '{'
-    attrs <- attrsParser
-    skipWS
-    _ <- char '}'
-    return (strip sel, attrs)
+    sel <- takeWhile (notInClass "{}")
+    c <- peekChar
+    case c of
+      Just '{' -> do
+        _ <- char '{'
+        attrs <- attrsParser
+        skipWS
+        _ <- char '}'
+        return (strip sel, attrs)
+      _ ->
+        fail "this is not a block"
 
 nestedBlockParser :: Parser NestedBlock
 nestedBlockParser = do

--- a/test/runtests.hs
+++ b/test/runtests.hs
@@ -50,6 +50,11 @@ main = hspec $ do
             , LeafBlock ("a, a:visited", [("text-decoration", "underline")])
             ]
           ]
+      parseNestedBlocks "@media whatever { foo { color: rgb(255, 255, 240); } }  bar { }"
+        `shouldBe` Right
+          [ NestedBlock "@media whatever" [ LeafBlock ("foo", [("color", "rgb(255, 255, 240)")]) ]
+          , LeafBlock ("bar", [])
+          ]
 
   describe "render" $ -- do
     it "works" $


### PR DESCRIPTION
This is a stopgap measure to enable this library to parse e.g. Bootstrap
4.3.1.

The problem can be illustrated by the example:

    1 | @media {
    2 |    foo {}
    3 | }
    4 | bar {}

`nestedParse` parses the first block inside a nested block  on its own,
(in this case: `foo {}`), then uses `blocksParser` to read the rest. The
previous version of `blocksParser` is too greedy and consumes everything
until the next '{'. In this case: `} bar` becomes a "selector", the `bar`
block becomes the next "subblock" of `@media` and the "absent" '}' for
`@media {` fails parsing.

This patch uses '}' as a character that is highly unlikely to happen
inside a selector (although it's still possible, e.g. `[attr="}"]`) and
highly likely to terminate one-block @-blocks.

Previously, css-text failed on Bootstrap 4.3.1 at the 94th block, now it
can parse all of its >1200 blocks (not completely correctly, but rather
fine for CSS and such a tiny library!).